### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/ForceDownload.php
+++ b/src/ForceDownload.php
@@ -27,7 +27,7 @@ class ForceDownload extends Plugin
         parent::init();
         self::$plugin = $this;
 
-        Craft::$app->view->twig->addExtension(new twigextensions\ForceDownloadTwigExtension());
+        Craft::$app->view->registerTwigExtension(new twigextensions\ForceDownloadTwigExtension());
 
         Craft::info(
             Craft::t(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.